### PR TITLE
update edilkamin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ If not, add an instance of `Edilkamin Stove` using the UI in the integration sec
   - Number of power ons
   - Running time
   - Current alarm
-  - Last alarm 
+  - Last alarm
+  - Autonomy time
+- Binary Sensor entities
+  - Pellet in Reserve status
 
 ## Issues / To-Do
 

--- a/custom_components/edilkamin/__init__.py
+++ b/custom_components/edilkamin/__init__.py
@@ -11,7 +11,7 @@ from .coordinator import EdilkaminCoordinator
 
 import json
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.FAN, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.FAN, Platform.SENSOR, Platform.SWITCH]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up edilkamin from a config entry."""

--- a/custom_components/edilkamin/binary_sensor.py
+++ b/custom_components/edilkamin/binary_sensor.py
@@ -1,0 +1,71 @@
+"""Binary sensor platform for Edilkamin."""
+from __future__ import annotations
+
+from .const import DOMAIN
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+#    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the stove with config flow."""
+    name = entry.data[CONF_NAME]
+    coordinator = hass.data[DOMAIN]["coordinator"]
+
+    async_add_entities(
+        [
+            PelletReserve(coordinator, name)
+        ],
+        update_before_add=False,
+    )
+
+
+class PelletReserve(CoordinatorEntity, BinarySensorEntity):
+    """Pellet in Reserve Binary sensor entity"""
+
+    def __init__(
+        self,
+        coordinator,
+        name: str,
+    ) -> None:
+        """Create the Edilkamin Pellet in Reserve binary sensor entity."""
+        super().__init__(coordinator)
+
+        self._mac_address = coordinator.get_mac()
+
+        self._attr_name = f"{name} Pellet in Reserve"
+        self._attr_unique_id = f"{self._mac_address}_pelletinreserve"
+        self._attr_icon = "mdi:storage-tank"
+
+        # Initial value
+        self._attr_is_on = (
+            self.coordinator.data["status"]["flags"]["is_pellet_in_reserve"]
+        )
+
+        self._attr_device_info = {
+            "identifiers": {("edilkamin", self._mac_address)}
+        }
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = (
+            self.coordinator.data["status"]["flags"]["is_pellet_in_reserve"]
+        )
+        self.async_write_ha_state()

--- a/custom_components/edilkamin/climate.py
+++ b/custom_components/edilkamin/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import edilkamin as ek
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import CONF_NAME, ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -77,10 +77,13 @@ class EdilkaminClimate(CoordinatorEntity, ClimateEntity):
     """Representation of a stove."""
 
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_supported_features = (ClimateEntityFeature.TARGET_TEMPERATURE |
                                 ClimateEntityFeature.FAN_MODE |
-                                ClimateEntityFeature.PRESET_MODE)
+                                ClimateEntityFeature.PRESET_MODE |
+                                ClimateEntityFeature.TURN_ON |
+                                ClimateEntityFeature.TURN_OFF)
     _attr_fan_modes = FAN_MODES
     _attr_preset_modes = PRESET_MODES
 
@@ -214,3 +217,9 @@ class EdilkaminClimate(CoordinatorEntity, ClimateEntity):
             )
 
         await self.coordinator.async_refresh()
+
+    async def async_turn_off(self) -> None:
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self) -> None:
+        await self.async_set_hvac_mode(HVACMode.HEAT)

--- a/custom_components/edilkamin/manifest.json
+++ b/custom_components/edilkamin/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "edilkamin",
   "name": "Edilkamin Stove",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "config_flow": true,
   "documentation": "https://github.com/nghaye/ha-edilkamin",
-  "requirements": ["edilkamin==1.2.0"],
+  "requirements": ["edilkamin==1.4.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/edilkamin/sensor.py
+++ b/custom_components/edilkamin/sensor.py
@@ -61,7 +61,8 @@ async def async_setup_entry(
             WorkingTime(coordinator, name, 4),
             WorkingTime(coordinator, name, 5),
             AlarmState(coordinator, name),
-            LastAlarm(coordinator, name)
+            LastAlarm(coordinator, name),
+            AutonomyTime(coordinator, name)
         ],
         update_before_add=False,
     )
@@ -230,4 +231,40 @@ class LastAlarm(CoordinatorEntity, SensorEntity):
         self._attr_extra_state_attributes["Alarm Code"] = last_alarm["type"]
         self._attr_extra_state_attributes["Date"] = datetime.fromtimestamp(
             last_alarm["timestamp"])
+        self.async_write_ha_state()
+
+
+class AutonomyTime(CoordinatorEntity, SensorEntity):
+    """Autonomy Time left sensor entity"""
+
+    def __init__(
+        self,
+        coordinator,
+        name: str,
+    ) -> None:
+        """Create the Edilkamin autonomy time sensor entity."""
+        super().__init__(coordinator)
+
+        self._mac_address = coordinator.get_mac()
+
+        self._attr_name = f"{name} Autonomy Time"
+        self._attr_unique_id = f"{self._mac_address}_autonomytime"
+        self._attr_icon = "mdi:timelapse"
+
+        # Initial value
+        self._attr_native_value = (
+            self.coordinator.data["status"]["pellet"]["autonomy_time"]
+        )
+
+        self._attr_device_info = {
+            "identifiers": {("edilkamin", self._mac_address)}
+        }
+
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = (
+            self.coordinator.data["status"]["pellet"]["autonomy_time"]
+        )
         self.async_write_ha_state()


### PR DESCRIPTION
- bump edilkamin API to 1.4.1
- add pellet in reserve binary sensor
- add autonomy time sensor
- replace deprecated TEMP_CELSIUS constant
- add TURN_ON and TURN_OFF ClimateEntityFeature to fix deprecation warning (https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded?_highlight=climateentityfeature)