### PR TITLE
Update climate.py for Home Assistant Core version 2025.1.0

### DIFF
--- a/custom_components/edilkamin/climate.py
+++ b/custom_components/edilkamin/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import edilkamin as ek
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import CONF_NAME, ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -77,7 +77,7 @@ class EdilkaminClimate(CoordinatorEntity, ClimateEntity):
     """Representation of a stove."""
 
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (ClimateEntityFeature.TARGET_TEMPERATURE |
                                 ClimateEntityFeature.FAN_MODE |
                                 ClimateEntityFeature.PRESET_MODE)


### PR DESCRIPTION
Fix: Replace deprecated TEMP_CELSIUS constant in Edilkamin integration for HA Core 2025.1.0 compatibility